### PR TITLE
fix(docs): deploy Pages from main, not release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,16 @@ name: Docs
 
 # Builds the Just the Docs site and deploys it to GitHub Pages. The API reference (Javadoc) is
 # hosted per-version by JitPack (https://jitpack.io/com/github/CrimsonWarpedcraft/cw-commons), so
-# this workflow only builds the prose site. Runs when a release is published (release.yml creates
-# drafts, so this fires only once the maintainer publishes); workflow_dispatch allows manual rebuilds.
+# this workflow only builds the prose site, which is release-independent. It deploys from `main`
+# (the github-pages environment only permits the default branch by default), so it runs on pushes
+# that touch the docs and via manual dispatch — not on release tags, which the environment blocks.
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 # Required by actions/deploy-pages.
@@ -23,8 +27,6 @@ concurrency:
 
 jobs:
   build:
-    # Skip prereleases so an -rc- publish never replaces the live stable docs.
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

Publishing release `v0.1.2` failed the docs deploy with:

> Tag "v0.1.2" is not allowed to deploy to github-pages due to environment protection rules.

The `github-pages` environment (auto-created when the Pages source is set to *GitHub Actions*) has a default protection rule that only allows the **default branch** to deploy. `docs.yml` was triggered by `release: published`, which runs in the **tag** context (`refs/tags/v0.1.2`), so the deploy job is rejected.

## Fix

The API reference now lives on JitPack, so the GitHub Pages site is just release-independent prose (landing + examples) that only changes when `docs/` changes. This switches the trigger to **push to `main`** (paths `docs/**` and the workflow itself) plus `workflow_dispatch`, so deploys always run from the default branch the environment permits. The now-irrelevant prerelease `if:` guard is removed.

- Docs still redeploy automatically when docs changes land on `main`.
- Manual refresh remains available via *Actions → Run workflow*.

## Alternative considered

Loosening the `github-pages` environment's *Deployment branches and tags* rule to allow `v*` tags would also fix it, but that's a repo-settings change (not code) and would keep redeploying the site on every release for no content change. Triggering from `main` is simpler and avoids wasted deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
